### PR TITLE
Allow selecting between virtual or local repositories

### DIFF
--- a/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryConstants.java
+++ b/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryConstants.java
@@ -7,6 +7,7 @@ package io.github.kierranm.teamcity.artifacts.artifactory;
 public class ArtifactoryConstants {
 
   public static final String ARTIFACTORY_URL = "storage.artifactory.url";
+  public static final String ARTIFACTORY_REPOSITORY_TYPE = "storage.artifactory.repository.type";
   public static final String ARTIFACTORY_REPOSITORY_KEY = "storage.artifactory.repository.key";
   public static final String ARTIFACTORY_USERNAME = "storage.artifactory.username";
   public static final String SECURE_ARTIFACTORY_PASSWORD = "secure:storage.artifactory.password";

--- a/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryUtil.java
+++ b/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryUtil.java
@@ -69,6 +69,11 @@ public class ArtifactoryUtil {
   }
 
   @Nullable
+  public static String getRepositoryType(@NotNull Map<String, String> params) {
+    return params.get(ArtifactoryConstants.ARTIFACTORY_REPOSITORY_TYPE);
+  }
+
+  @Nullable
   public static String getUsername(@NotNull Map<String, String> params) {
     return params.get(ArtifactoryConstants.ARTIFACTORY_USERNAME);
   }

--- a/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/ArtifactoryParametersProvider.java
+++ b/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/ArtifactoryParametersProvider.java
@@ -7,6 +7,10 @@ public class ArtifactoryParametersProvider {
     return ArtifactoryConstants.ARTIFACTORY_URL;
   }
 
+  public String getRepositoryType() {
+    return ArtifactoryConstants.ARTIFACTORY_REPOSITORY_TYPE;
+  }
+
   public String getRepositoryKey() {
     return ArtifactoryConstants.ARTIFACTORY_REPOSITORY_KEY;
   }

--- a/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/RepositoriesResourceHandler.java
+++ b/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/RepositoriesResourceHandler.java
@@ -2,11 +2,17 @@ package io.github.kierranm.teamcity.artifacts.artifactory.web;
 
 import com.intellij.openapi.diagnostic.Logger;
 import java.util.Map;
+
+import io.github.kierranm.teamcity.artifacts.artifactory.ArtifactoryUtil;
 import org.jdom.Content;
 import org.jdom.Element;
 import org.jfrog.artifactory.client.Artifactory;
 import org.jfrog.artifactory.client.model.LightweightRepository;
+import org.jfrog.artifactory.client.model.RepositoryType;
+import org.springframework.security.access.method.P;
+
 import static org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl.LOCAL;
+import static org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl.VIRTUAL;
 
 
 /**
@@ -15,12 +21,29 @@ import static org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl.LOCAL;
 public class RepositoriesResourceHandler extends ArtifactoryClientResourceHandler {
 
   private final static Logger LOG = Logger.getInstance(RepositoriesResourceHandler.class.getName());
+  private final static String LOCAL_REPO = "local";
+  private final static String VIRTUAL_REPO = "virtual";
 
   @Override
   public Content getContent(final Artifactory afClient, final Map<String, String> parameters) {
     LOG.warn(parameters.toString());
     final Element repositoriesElement = new Element("repositories");
-    for (LightweightRepository repo : afClient.repositories().list(LOCAL)) {
+
+    RepositoryType repoType;
+    String selectedRepoType = ArtifactoryUtil.getRepositoryType(parameters);
+
+    switch (selectedRepoType) {
+      case LOCAL_REPO:
+        repoType = LOCAL;
+        break;
+      case VIRTUAL_REPO:
+        repoType = VIRTUAL;
+        break;
+      default:
+        repoType = LOCAL;
+        break;
+    }
+    for (LightweightRepository repo : afClient.repositories().list(repoType)) {
       final Element repoElement = new Element("repository");
       final String repoKey = repo.getKey();
       repoElement.setText(repoKey);

--- a/artifactory-artifact-storage-server/src/main/resources/buildServerResources/artifactory_storage_settings.jsp
+++ b/artifactory-artifact-storage-server/src/main/resources/buildServerResources/artifactory_storage_settings.jsp
@@ -44,6 +44,19 @@
         </td>
     </tr>
     <tr>
+        <th><label for="${params.repositoryType}">Artifactory repository type: <l:star/></label></th>
+        <td>
+            <div class="posRel">
+                <c:set var="repository" value="${propertiesBean.properties[params.repositoryKey]}"/>
+                <props:selectProperty name="${params.repositoryType}" className="longField">
+                    <props:option value="local">Local</props:option>
+                    <props:option value="virtual">Virtual</props:option>
+                </props:selectProperty>
+            </div>
+            <span class="error" id="error_${params.repositoryType}"></span>
+        </td>
+    </tr>
+    <tr>
         <th><label for="${params.repositoryKey}">Artifactory repository name: <l:star/></label></th>
         <td>
             <div class="posRel">
@@ -65,6 +78,7 @@
 <script type="text/javascript">
     var username = BS.Util.escapeId('${params.username}');
     var url = BS.Util.escapeId('${params.url}');
+    var repositoryType = BS.Util.escapeId('${params.repositoryType}');
     var password = BS.Util.escapeId('secure:${params.password}');
     var accessToken = BS.Util.escapeId('secure:${params.accessToken}');
     var pathPrefix = BS.Util.escapeId('${params.pathPrefix}');
@@ -115,7 +129,7 @@
                     $refreshButton.removeClass('icon-spin');
                 });
     }
-    $j(document).on('change', url + ', ' + username + ', ' + password + ', ' + accessToken, function () {
+    $j(document).on('change', url + ', ' + username + ', ' + password + ', ' + accessToken + ', ' + repositoryType, function () {
         loadRepositories();
     });
     $j(document).on('click', '#repositories-refresh', function () {


### PR DESCRIPTION
## What??

Adding a dropdown to allow selecting between `local` and `virtual` repository types

## Why??

This allows you to point the plugin at a virtual repo that may be backed by locals/remotes in multiple regions. The artefacts will be deployed to the default deployment repository for the virtual.
