### PR TITLE
optionally parallelize uploading artifacts to Artifactory

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,8 +10,8 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="artifactory-artifact-storage-agent_main" target="1.6" />
-      <module name="artifactory-artifact-storage-agent_test" target="1.6" />
+      <module name="artifactory-artifact-storage-agent_main" target="1.8" />
+      <module name="artifactory-artifact-storage-agent_test" target="1.8" />
       <module name="artifactory-artifact-storage-common_main" target="1.8" />
       <module name="artifactory-artifact-storage-common_test" target="1.8" />
       <module name="artifactory-artifact-storage-server_main" target="1.8" />

--- a/artifactory-artifact-storage-agent/build.gradle
+++ b/artifactory-artifact-storage-agent/build.gradle
@@ -23,10 +23,10 @@ agentPlugin.version = null
 agentPlugin.baseName = projectIds.artifact + '-agent'
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = "1.6"
-    targetCompatibility = "1.6"
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
 
-    if (project.hasProperty('JDK_16')) {
-        options.bootstrapClasspath = layout.files("$JDK_16/jre/lib/rt.jar")
+    if (project.hasProperty('JDK_18')) {
+        options.bootstrapClasspath = layout.files("$JDK_18/jre/lib/rt.jar")
     }
 }

--- a/artifactory-artifact-storage-agent/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/publish/ArtifactoryFileUploader.java
+++ b/artifactory-artifact-storage-agent/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/publish/ArtifactoryFileUploader.java
@@ -1,24 +1,28 @@
 package io.github.kierranm.teamcity.artifacts.artifactory.publish;
 
-import org.jfrog.artifactory.client.RepositoryHandle;
-import org.jfrog.artifactory.client.model.File;
-import org.jfrog.artifactory.client.Artifactory;
 import com.intellij.openapi.diagnostic.Logger;
+import io.github.kierranm.teamcity.artifacts.artifactory.ArtifactoryUtil;
 import jetbrains.buildServer.agent.AgentRunningBuild;
 import jetbrains.buildServer.agent.ArtifactPublishingFailedException;
 import jetbrains.buildServer.agent.BuildAgentConfiguration;
 import jetbrains.buildServer.artifacts.ArtifactDataInstance;
-import io.github.kierranm.teamcity.artifacts.artifactory.ArtifactoryUtil;
-import jetbrains.buildServer.util.CollectionsUtil;
-import jetbrains.buildServer.util.Converter;
 import jetbrains.buildServer.util.StringUtil;
-import org.jetbrains.annotations.NotNull;
-
 import org.apache.http.client.HttpResponseException;
-import java.util.ArrayList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jfrog.artifactory.client.Artifactory;
+import org.jfrog.artifactory.client.RepositoryHandle;
+
+import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static io.github.kierranm.teamcity.artifacts.artifactory.ArtifactoryUtil.getRepositoryKey;
 
@@ -40,8 +44,6 @@ public class ArtifactoryFileUploader {
   public Collection<ArtifactDataInstance> publishFiles(@NotNull final AgentRunningBuild build,
                                                        @NotNull final String pathPrefix,
                                                        @NotNull final Map<java.io.File, String> filesToPublish) {
-    final String homeDir = myBuildAgentConfiguration.getAgentHomeDirectory().getPath();
-
     final Map<String, String> params = ArtifactoryUtil.validateParameters(build.getArtifactStorageSettings());
     final String repositoryKey = getRepositoryKey(params);
     final Artifactory afClient = ArtifactoryUtil.getClient(params);
@@ -51,37 +53,74 @@ public class ArtifactoryFileUploader {
       throw new ArtifactPublishingFailedException("Target Artifactory artifact repository " + repositoryKey + " doesn't exist", false, null);
     }
 
+    int parallelism = ArtifactoryUtil.getParallelism(params);
+    ExecutorService parallelExecutor = Executors.newFixedThreadPool(parallelism);
+    AtomicReference<Throwable> fatalError = new AtomicReference<>(null);
+
+    List<ArtifactDataInstance> artifacts;
     try {
-      final List<ArtifactDataInstance> artifacts = new ArrayList<ArtifactDataInstance>();
-      CollectionsUtil.convertAndFilterNulls(filesToPublish.entrySet(), new Converter<File, Map.Entry<java.io.File, String>>() {
-          @Override
-          public File createFrom(@NotNull Map.Entry<java.io.File, String> entry) {
-            final java.io.File file = entry.getKey();
-            final String path = entry.getValue();
-            final String artifactPath = ArtifactoryUtil.normalizeArtifactPath(path, file);
-            final String fullPath = pathPrefix + artifactPath;
+      List<Future<ArtifactDataInstance>> futures = filesToPublish.entrySet().stream().sequential()
+              .sorted((a, b) -> Long.compare(b.getKey().length(), a.getKey().length()))  // upload larger files first
+              .map(e -> parallelExecutor.submit(() -> uploadArtifactTask(build, pathPrefix, repository, fatalError, e)))
+              .collect(Collectors.toList());
+      artifacts = futures.stream()
+              .map(this::quietlyGetResult)
+              .collect(Collectors.toList());
+    } finally {
+      try {
+        parallelExecutor.shutdown();
+      } catch (Exception e) {
+        LOG.error(e);
+      }
+    }
 
-            artifacts.add(ArtifactDataInstance.create(artifactPath, file.length()));
+    if (fatalError.get() != null) {
+      throw new ArtifactPublishingFailedException(fatalError.get().getMessage(), false, fatalError.get());
+    }
 
-            File uploadedFile = repository.upload(fullPath, file).doUpload();
+    return artifacts;
+  }
 
-            return uploadedFile;
-          }
-      });
-      return artifacts;
+  @Nullable
+  private ArtifactDataInstance uploadArtifactTask(@NotNull AgentRunningBuild build, @NotNull String pathPrefix, RepositoryHandle repository, AtomicReference<Throwable> fatalError, Map.Entry<File, String> entry) {
+    if (fatalError.get() != null) {
+      return null;
+    }
+
+    final File file = entry.getKey();
+    final String path = entry.getValue();
+    final String artifactPath = ArtifactoryUtil.normalizeArtifactPath(path, file);
+    final String fullPath = pathPrefix + artifactPath;
+
+    try {
+      repository.upload(fullPath, file).doUpload();
     } catch (Throwable t) {
-      final String message = t.getMessage();
+      fatalError.set(t);
       if (t instanceof HttpResponseException) {
-        final HttpResponseException ex = (HttpResponseException)t;
+        final HttpResponseException ex = (HttpResponseException) t;
+        final String message = ex.getMessage();
         final int code = ex.getStatusCode();
-
         if (StringUtil.isNotEmpty(message)) {
           LOG.warn(code + ": " + message);
           build.getBuildLogger().error(message);
         }
       }
+      return null;
+    }
 
-      throw new ArtifactPublishingFailedException(message, false, t);
+    return ArtifactDataInstance.create(artifactPath, file.length());
+  }
+
+  private <T> T quietlyGetResult(java.util.concurrent.Future<T> f) {
+    try {
+      return f.get();
+    } catch (InterruptedException e) {
+      LOG.error(e);
+      throw new ArtifactPublishingFailedException(e.getMessage(), false, e);
+    } catch (ExecutionException e) {
+      LOG.error(e);
+      throw new ArtifactPublishingFailedException(e.getCause().getMessage(), false, e.getCause());
     }
   }
+
 }

--- a/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryConstants.java
+++ b/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryConstants.java
@@ -23,4 +23,6 @@ public class ArtifactoryConstants {
 
   public static final String ARTIFACTORY_CLEANUP_BATCH_SIZE = "storage.artifactory.cleanup.batchSize";
   public static final String ARTIFACTORY_CLEANUP_USE_PARALLEL = "storage.artifactory.cleanup.useParallel";
+
+  public static final String ARTIFACTORY_UPLOAD_PARALLELISM = "storage.artifactory.upload.parallelism";
 }

--- a/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryUtil.java
+++ b/artifactory-artifact-storage-common/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/ArtifactoryUtil.java
@@ -40,6 +40,10 @@ public class ArtifactoryUtil {
         invalids.put(ArtifactoryConstants.SECURE_ARTIFACTORY_ACCESS_TOKEN, "Artifactory password or token must not be empty if username is set");
       }
     }
+    String parallelism = params.get(ArtifactoryConstants.ARTIFACTORY_UPLOAD_PARALLELISM);
+    if (!StringUtil.isEmptyOrSpaces(parallelism) && !StringUtil.isAPositiveNumber(parallelism)) {
+      invalids.put(ArtifactoryConstants.ARTIFACTORY_UPLOAD_PARALLELISM, "Parallelism level must be a positive number if set");
+    }
     return invalids;
   }
 
@@ -96,6 +100,14 @@ public class ArtifactoryUtil {
   @Nullable
   public static String getPathPrefix(@NotNull Map<String, String> properties) {
     return properties.get(ArtifactoryConstants.ARTIFACTORY_REPOSITORY_PATH_PREFIX_ATTR);
+  }
+
+  public static int getParallelism(@NotNull Map<String, String> properties) {
+    try {
+      return Integer.parseInt(properties.get(ArtifactoryConstants.ARTIFACTORY_UPLOAD_PARALLELISM));
+    } catch (Exception e) {
+      return 1;
+    }
   }
 
   public static String getContentType(File file) {

--- a/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/ArtifactoryParametersProvider.java
+++ b/artifactory-artifact-storage-server/src/main/java/io/github/kierranm/teamcity/artifacts/artifactory/web/ArtifactoryParametersProvider.java
@@ -31,6 +31,10 @@ public class ArtifactoryParametersProvider {
     return ArtifactoryConstants.ARTIFACTORY_ACCESS_TOKEN;
   }
 
+  public String getParallelism() {
+    return ArtifactoryConstants.ARTIFACTORY_UPLOAD_PARALLELISM;
+  }
+
   public String getContainersPath() {
     return String.format("/plugins/artifactory-artifact-storage/%s.html", ArtifactoryConstants.ARTIFACTORY_SETTINGS_PATH);
   }

--- a/artifactory-artifact-storage-server/src/main/resources/buildServerResources/artifactory_storage_settings.jsp
+++ b/artifactory-artifact-storage-server/src/main/resources/buildServerResources/artifactory_storage_settings.jsp
@@ -73,6 +73,14 @@
             <span class="error" id="error_${params.repositoryKey}"></span>
         </td>
     </tr>
+    <tr>
+        <th><label for="${params.parallelism}">Upload parallelism: </label></th>
+        <td>
+            <props:textProperty name="${params.parallelism}" className="longField" maxlength="4"/>
+            <span class="smallNote">Number of simultaneous upload requests to Artifactory (default: 1)</span>
+            <span class="error" id="error_${params.parallelism}"></span>
+        </td>
+    </tr>
 </l:settingsGroup>
 
 <script type="text/javascript">


### PR DESCRIPTION
Some of our builds generate thousands of artifacts (HTML acceptance test output), which take an age to upload to our Artifactory instance.  We find this is due to per-request processing overhead - number of files in our artifact output affects artifact upload times more than their total size.

So, I've modified ArtifactoryFileUploader to be able to perform uploads using multiple threads running in parallel.  This has reduced our upload times substantially.